### PR TITLE
feat: Practice Lead Authorization System (#7)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -9,9 +9,12 @@ A FastAPI application that enables Slalom consultants to register their capabili
 ## Features
 
 - View all available consulting capabilities
-- Register consultant expertise and availability
+- Secure sign-in for practice leads and consultants
+- Register consultant expertise and availability with role-based workflows
 - Track skill levels and certifications
 - Manage capability capacity and team assignments
+- Practice lead approval workflow for consultant self-registration requests
+- Audit log API for capability changes (practice lead only)
 
 ## Getting Started
 
@@ -37,8 +40,21 @@ A FastAPI application that enables Slalom consultants to register their capabili
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/capabilities`                                                   | Get all capabilities with details and current consultant assignments |
-| POST   | `/capabilities/{capability_name}/register?email=consultant@slalom.com` | Register consultant for a capability                     |
-| DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Unregister consultant from a capability              |
+| POST   | `/auth/login`                                                     | Sign in and receive a bearer access token                           |
+| GET    | `/auth/me`                                                        | Get current signed-in user profile                                  |
+| POST   | `/capabilities/{capability_name}/register?email=consultant@slalom.com` | Practice lead direct register or consultant self-request            |
+| POST   | `/capabilities/{capability_name}/approve?email=consultant@slalom.com` | Practice lead approval endpoint for pending requests                |
+| DELETE | `/capabilities/{capability_name}/unregister?email=consultant@slalom.com` | Practice lead unregister endpoint                                  |
+| GET    | `/audit-logs`                                                     | View capability audit trail (practice lead only)                    |
+
+## Demo Credentials
+
+Credentials are stored in `practice_leads.json` with salted password hashes.
+
+- Practice lead: `tech.lead` / `LeadTech!2026`
+- Consultant: `alex.consultant` / `Consultant!2026`
+
+Use the "Sign In" button in the header to authenticate.
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,19 @@ A FastAPI application that enables Slalom consultants to register their
 capabilities and manage consulting expertise across the organization.
 """
 
-from fastapi import FastAPI, HTTPException
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
-from pathlib import Path
+from pydantic import BaseModel
 
 app = FastAPI(title="Slalom Capabilities Management API",
               description="API for managing consulting capabilities and consultant expertise")
@@ -18,6 +26,15 @@ app = FastAPI(title="Slalom Capabilities Management API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+AUTH_FILE_PATH = current_dir / "practice_leads.json"
+TOKEN_SECRET = os.getenv("TOKEN_SECRET", "dev-only-change-me")
+TOKEN_EXPIRES_SECONDS = int(os.getenv("TOKEN_EXPIRES_SECONDS", "28800"))
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
 
 # In-memory capabilities database
 capabilities = {
@@ -104,6 +121,166 @@ capabilities = {
     }
 }
 
+# In-memory audit events
+audit_logs: list[dict[str, Any]] = []
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _hash_password(password: str, salt: str) -> str:
+    combined = f"{salt}:{password}".encode("utf-8")
+    return hashlib.sha256(combined).hexdigest()
+
+
+def _load_auth_users() -> dict[str, dict[str, Any]]:
+    if not AUTH_FILE_PATH.exists():
+        raise RuntimeError("practice_leads.json was not found")
+
+    with AUTH_FILE_PATH.open("r", encoding="utf-8") as credentials_file:
+        raw_data = json.load(credentials_file)
+
+    users = raw_data.get("users", [])
+    return {user["username"]: user for user in users}
+
+
+def _public_user(user: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "username": user["username"],
+        "display_name": user.get("display_name", user["username"]),
+        "email": user.get("email", ""),
+        "role": user.get("role", "consultant"),
+        "practice_areas": user.get("practice_areas", []),
+        "permissions": user.get("permissions", [])
+    }
+
+
+def _create_access_token(user: dict[str, Any]) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload = {
+        "sub": user["username"],
+        "role": user.get("role", "consultant"),
+        "email": user.get("email", ""),
+        "exp": int(time.time()) + TOKEN_EXPIRES_SECONDS,
+    }
+
+    encoded_header = _b64url_encode(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    encoded_payload = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{encoded_header}.{encoded_payload}".encode("utf-8")
+    signature = hmac.new(TOKEN_SECRET.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    encoded_signature = _b64url_encode(signature)
+    return f"{encoded_header}.{encoded_payload}.{encoded_signature}"
+
+
+def _decode_access_token(token: str) -> dict[str, Any]:
+    try:
+        encoded_header, encoded_payload, encoded_signature = token.split(".")
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="Malformed token") from exc
+
+    signing_input = f"{encoded_header}.{encoded_payload}".encode("utf-8")
+    expected_signature = hmac.new(
+        TOKEN_SECRET.encode("utf-8"),
+        signing_input,
+        hashlib.sha256,
+    ).digest()
+
+    provided_signature = _b64url_decode(encoded_signature)
+    if not hmac.compare_digest(expected_signature, provided_signature):
+        raise HTTPException(status_code=401, detail="Invalid token signature")
+
+    payload = json.loads(_b64url_decode(encoded_payload).decode("utf-8"))
+    if payload.get("exp", 0) < int(time.time()):
+        raise HTTPException(status_code=401, detail="Token has expired")
+
+    return payload
+
+
+def _extract_token(authorization: Optional[str]) -> Optional[str]:
+    if not authorization:
+        return None
+    if not authorization.startswith("Bearer "):
+        return None
+    return authorization.split(" ", maxsplit=1)[1]
+
+
+def _ensure_capability(capability_name: str) -> dict[str, Any]:
+    if capability_name not in capabilities:
+        raise HTTPException(status_code=404, detail="Capability not found")
+    return capabilities[capability_name]
+
+
+def _append_audit(action: str, capability_name: str, target_email: str, actor: dict[str, Any]) -> None:
+    audit_logs.insert(0, {
+        "action": action,
+        "capability": capability_name,
+        "target_email": target_email,
+        "actor": actor.get("username"),
+        "actor_role": actor.get("role"),
+        "timestamp": int(time.time()),
+    })
+
+
+auth_users = _load_auth_users()
+
+
+def get_current_user(authorization: Optional[str] = Header(default=None)) -> dict[str, Any]:
+    token = _extract_token(authorization)
+    if not token:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    payload = _decode_access_token(token)
+    username = payload.get("sub")
+    user = auth_users.get(username)
+    if not user:
+        raise HTTPException(status_code=401, detail="Unknown user")
+    return user
+
+
+def get_optional_user(authorization: Optional[str] = Header(default=None)) -> Optional[dict[str, Any]]:
+    token = _extract_token(authorization)
+    if not token:
+        return None
+    try:
+        payload = _decode_access_token(token)
+    except HTTPException:
+        return None
+    return auth_users.get(payload.get("sub"))
+
+
+def require_practice_lead(current_user: dict[str, Any] = Depends(get_current_user)) -> dict[str, Any]:
+    if current_user.get("role") != "practice_lead":
+        raise HTTPException(status_code=403, detail="Practice lead role required")
+    return current_user
+
+
+@app.post("/auth/login")
+def login(payload: LoginRequest):
+    user = auth_users.get(payload.username)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    expected_hash = _hash_password(payload.password, user["salt"])
+    if not hmac.compare_digest(expected_hash, user["password_hash"]):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    return {
+        "access_token": _create_access_token(user),
+        "token_type": "bearer",
+        "user": _public_user(user),
+    }
+
+
+@app.get("/auth/me")
+def auth_me(current_user: dict[str, Any] = Depends(get_current_user)):
+    return {"user": _public_user(current_user)}
+
 
 @app.get("/")
 def root():
@@ -111,49 +288,117 @@ def root():
 
 
 @app.get("/capabilities")
-def get_capabilities():
-    return capabilities
+def get_capabilities(current_user: Optional[dict[str, Any]] = Depends(get_optional_user)):
+    response: dict[str, Any] = {}
+    is_practice_lead = bool(current_user and current_user.get("role") == "practice_lead")
+
+    for capability_name, details in capabilities.items():
+        capability_copy = {
+            "description": details["description"],
+            "practice_area": details["practice_area"],
+            "skill_levels": details["skill_levels"],
+            "certifications": details["certifications"],
+            "industry_verticals": details["industry_verticals"],
+            "capacity": details["capacity"],
+            "consultants": details["consultants"],
+        }
+
+        pending_requests = details.get("pending_requests", [])
+        if is_practice_lead:
+            capability_copy["pending_requests"] = pending_requests
+        else:
+            capability_copy["pending_request_count"] = len(pending_requests)
+
+        response[capability_name] = capability_copy
+
+    return response
 
 
 @app.post("/capabilities/{capability_name}/register")
-def register_for_capability(capability_name: str, email: str):
+def register_for_capability(
+    capability_name: str,
+    email: str,
+    current_user: dict[str, Any] = Depends(get_current_user),
+):
     """Register a consultant for a capability"""
-    # Validate capability exists
-    if capability_name not in capabilities:
-        raise HTTPException(status_code=404, detail="Capability not found")
+    capability = _ensure_capability(capability_name)
+    pending_requests = capability.setdefault("pending_requests", [])
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
-
-    # Validate consultant is not already registered
     if email in capability["consultants"]:
         raise HTTPException(
             status_code=400,
             detail="Consultant is already registered for this capability"
         )
 
-    # Add consultant
+    if current_user.get("role") == "practice_lead":
+        capability["consultants"].append(email)
+        if email in pending_requests:
+            pending_requests.remove(email)
+        _append_audit("register", capability_name, email, current_user)
+        return {"message": f"Registered {email} for {capability_name}"}
+
+    if current_user.get("role") == "consultant":
+        if email.lower() != current_user.get("email", "").lower():
+            raise HTTPException(status_code=403, detail="Consultants can only register themselves")
+
+        if email in pending_requests:
+            raise HTTPException(status_code=400, detail="Registration request is already pending")
+
+        pending_requests.append(email)
+        _append_audit("request_registration", capability_name, email, current_user)
+        return {
+            "message": (
+                f"Submitted registration request for {email} on {capability_name}. "
+                "A practice lead must approve it."
+            )
+        }
+
+    raise HTTPException(status_code=403, detail="Unknown role")
+
+
+@app.post("/capabilities/{capability_name}/approve")
+def approve_registration(
+    capability_name: str,
+    email: str,
+    current_user: dict[str, Any] = Depends(require_practice_lead),
+):
+    """Approve a consultant's registration request for a capability"""
+    capability = _ensure_capability(capability_name)
+    pending_requests = capability.setdefault("pending_requests", [])
+
+    if email in capability["consultants"]:
+        raise HTTPException(status_code=400, detail="Consultant is already registered")
+
+    if email not in pending_requests:
+        raise HTTPException(status_code=404, detail="No pending registration found for this consultant")
+
+    pending_requests.remove(email)
     capability["consultants"].append(email)
-    return {"message": f"Registered {email} for {capability_name}"}
+    _append_audit("approve_registration", capability_name, email, current_user)
+    return {"message": f"Approved {email} for {capability_name}"}
 
 
 @app.delete("/capabilities/{capability_name}/unregister")
-def unregister_from_capability(capability_name: str, email: str):
+def unregister_from_capability(
+    capability_name: str,
+    email: str,
+    current_user: dict[str, Any] = Depends(require_practice_lead),
+):
     """Unregister a consultant from a capability"""
-    # Validate capability exists
-    if capability_name not in capabilities:
-        raise HTTPException(status_code=404, detail="Capability not found")
+    capability = _ensure_capability(capability_name)
 
-    # Get the specific capability
-    capability = capabilities[capability_name]
-
-    # Validate consultant is registered
     if email not in capability["consultants"]:
         raise HTTPException(
             status_code=400,
             detail="Consultant is not registered for this capability"
         )
 
-    # Remove consultant
     capability["consultants"].remove(email)
+    _append_audit("unregister", capability_name, email, current_user)
     return {"message": f"Unregistered {email} from {capability_name}"}
+
+
+@app.get("/audit-logs")
+def get_audit_logs(current_user: dict[str, Any] = Depends(require_practice_lead)):
+    _ = current_user
+    return {"items": audit_logs[:200]}

--- a/src/practice_leads.json
+++ b/src/practice_leads.json
@@ -1,0 +1,47 @@
+{
+  "users": [
+    {
+      "username": "tech.lead",
+      "display_name": "Taylor Practice Lead",
+      "email": "taylor.lead@slalom.com",
+      "role": "practice_lead",
+      "practice_areas": ["Technology"],
+      "permissions": [
+        "manage_capabilities",
+        "approve_registrations",
+        "view_audit_logs",
+        "manage_capacity"
+      ],
+      "salt": "slalom-tech-lead-salt",
+      "password_hash": "f53025ca9b44df94bf2858ba3181c2ac77a4e907b344de207cf00f481a82a2d1"
+    },
+    {
+      "username": "strategy.lead",
+      "display_name": "Morgan Strategy Lead",
+      "email": "morgan.lead@slalom.com",
+      "role": "practice_lead",
+      "practice_areas": ["Strategy", "Operations"],
+      "permissions": [
+        "manage_capabilities",
+        "approve_registrations",
+        "view_audit_logs",
+        "manage_capacity"
+      ],
+      "salt": "slalom-strategy-lead-salt",
+      "password_hash": "7825165002dba7819d2bdb27df88243f1b054b7af684071834630857776a8f56"
+    },
+    {
+      "username": "alex.consultant",
+      "display_name": "Alex Consultant",
+      "email": "alex.consultant@slalom.com",
+      "role": "consultant",
+      "practice_areas": ["Technology"],
+      "permissions": [
+        "view_capabilities",
+        "request_registration"
+      ],
+      "salt": "slalom-consultant-salt",
+      "password_hash": "b998d4516d78ff925c122b9cd6f0f8adee3fd011e8bd90f28d266351a2c91c94"
+    }
+  ]
+}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,47 +3,179 @@ document.addEventListener("DOMContentLoaded", () => {
   const capabilitySelect = document.getElementById("capability");
   const registerForm = document.getElementById("register-form");
   const messageDiv = document.getElementById("message");
+  const registerHelp = document.getElementById("register-help");
+  const emailInput = document.getElementById("email");
 
-  // Function to fetch capabilities from API
+  const loginBtn = document.getElementById("login-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authUser = document.getElementById("auth-user");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLoginBtn = document.getElementById("cancel-login-btn");
+
+  const authState = {
+    token: localStorage.getItem("slalom_access_token"),
+    user: null,
+  };
+
+  function getAuthHeaders() {
+    if (!authState.token) {
+      return {};
+    }
+    return { Authorization: `Bearer ${authState.token}` };
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type || "info";
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function clearCapabilityOptions() {
+    capabilitySelect.innerHTML = '<option value="">-- Select a capability --</option>';
+  }
+
+  function openLoginModal() {
+    loginModal.classList.remove("hidden");
+    loginModal.setAttribute("aria-hidden", "false");
+  }
+
+  function closeLoginModal() {
+    loginModal.classList.add("hidden");
+    loginModal.setAttribute("aria-hidden", "true");
+    loginForm.reset();
+  }
+
+  function updateRegisterFormMode() {
+    const submitButton = registerForm.querySelector('button[type="submit"]');
+
+    if (!authState.user) {
+      emailInput.disabled = true;
+      capabilitySelect.disabled = true;
+      submitButton.disabled = true;
+      submitButton.textContent = "Sign In To Continue";
+      registerHelp.textContent = "Sign in as a practice lead or consultant to continue.";
+      return;
+    }
+
+    capabilitySelect.disabled = false;
+    submitButton.disabled = false;
+
+    if (authState.user.role === "consultant") {
+      emailInput.value = authState.user.email;
+      emailInput.disabled = true;
+      submitButton.textContent = "Request Registration";
+      registerHelp.textContent = "Consultants submit requests that practice leads must approve.";
+      return;
+    }
+
+    emailInput.disabled = false;
+    submitButton.textContent = "Register Expertise";
+    registerHelp.textContent = "Practice leads can directly register and approve consultant requests.";
+  }
+
+  function updateAuthUI() {
+    if (authState.user) {
+      authUser.textContent = `${authState.user.display_name} (${authState.user.role})`;
+      authUser.classList.remove("hidden");
+      loginBtn.classList.add("hidden");
+      logoutBtn.classList.remove("hidden");
+    } else {
+      authUser.classList.add("hidden");
+      loginBtn.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+    }
+
+    updateRegisterFormMode();
+  }
+
+  async function restoreSession() {
+    if (!authState.token) {
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: getAuthHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error("Session token is no longer valid");
+      }
+
+      const payload = await response.json();
+      authState.user = payload.user;
+    } catch (error) {
+      localStorage.removeItem("slalom_access_token");
+      authState.token = null;
+      authState.user = null;
+    }
+  }
+
   async function fetchCapabilities() {
     try {
-      const response = await fetch("/capabilities");
+      const response = await fetch("/capabilities", {
+        headers: getAuthHeaders(),
+      });
       const capabilities = await response.json();
 
-      // Clear loading message
       capabilitiesList.innerHTML = "";
+      clearCapabilityOptions();
 
-      // Populate capabilities list
+      const isPracticeLead = authState.user && authState.user.role === "practice_lead";
+
       Object.entries(capabilities).forEach(([name, details]) => {
         const capabilityCard = document.createElement("div");
         capabilityCard.className = "capability-card";
 
         const availableCapacity = details.capacity || 0;
         const currentConsultants = details.consultants ? details.consultants.length : 0;
+        const pendingRequests = details.pending_requests || [];
+        const pendingCount = details.pending_request_count || 0;
 
-        // Create consultants HTML with delete icons
         const consultantsHTML =
           details.consultants && details.consultants.length > 0
             ? `<div class="consultants-section">
               <h5>Registered Consultants:</h5>
               <ul class="consultants-list">
                 ${details.consultants
-                  .map(
-                    (email) =>
-                      `<li><span class="consultant-email">${email}</span><button class="delete-btn" data-capability="${name}" data-email="${email}">❌</button></li>`
-                  )
+                  .map((email) => {
+                    const actionButton = isPracticeLead
+                      ? `<button class="delete-btn" data-capability="${name}" data-email="${email}" title="Remove consultant">Remove</button>`
+                      : "";
+                    return `<li><span class="consultant-email">${email}</span>${actionButton}</li>`;
+                  })
                   .join("")}
               </ul>
             </div>`
             : `<p><em>No consultants registered yet</em></p>`;
 
+        const pendingHTML = isPracticeLead
+          ? `<div class="pending-section">
+              <h5>Pending Requests:</h5>
+              ${pendingRequests.length > 0
+                ? `<ul class="consultants-list">
+                    ${pendingRequests
+                      .map(
+                        (email) => `<li><span class="consultant-email">${email}</span><button class="approve-btn" data-capability="${name}" data-email="${email}">Approve</button></li>`
+                      )
+                      .join("")}
+                  </ul>`
+                : '<p><em>No pending requests</em></p>'}
+            </div>`
+          : `<p><strong>Pending Requests:</strong> ${pendingCount}</p>`;
+
         capabilityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Practice Area:</strong> ${details.practice_area}</p>
-          <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(', ') : 'Not specified'}</p>
+          <p><strong>Industry Verticals:</strong> ${details.industry_verticals ? details.industry_verticals.join(", ") : "Not specified"}</p>
           <p><strong>Capacity:</strong> ${availableCapacity} hours/week available</p>
           <p><strong>Current Team:</strong> ${currentConsultants} consultants</p>
+          ${pendingHTML}
           <div class="consultants-container">
             ${consultantsHTML}
           </div>
@@ -51,25 +183,24 @@ document.addEventListener("DOMContentLoaded", () => {
 
         capabilitiesList.appendChild(capabilityCard);
 
-        // Add option to select dropdown
         const option = document.createElement("option");
         option.value = name;
         option.textContent = name;
         capabilitySelect.appendChild(option);
       });
 
-      // Add event listeners to delete buttons
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+      document.querySelectorAll(".approve-btn").forEach((button) => {
+        button.addEventListener("click", handleApprove);
+      });
     } catch (error) {
-      capabilitiesList.innerHTML =
-        "<p>Failed to load capabilities. Please try again later.</p>";
+      capabilitiesList.innerHTML = "<p>Failed to load capabilities. Please try again later.</p>";
       console.error("Error fetching capabilities:", error);
     }
   }
 
-  // Handle unregister functionality
   async function handleUnregister(event) {
     const button = event.target;
     const capability = button.getAttribute("data-capability");
@@ -77,86 +208,141 @@ document.addEventListener("DOMContentLoaded", () => {
 
     try {
       const response = await fetch(
-        `/capabilities/${encodeURIComponent(
-          capability
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        `/capabilities/${encodeURIComponent(capability)}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-
-        // Refresh capabilities list to show updated consultants
+        showMessage(result.message, "success");
         fetchCapabilities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "Could not unregister consultant.", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister consultant.", "error");
       console.error("Error unregistering:", error);
     }
   }
 
-  // Handle form submission
-  registerForm.addEventListener("submit", async (event) => {
-    event.preventDefault();
-
-    const email = document.getElementById("email").value;
-    const capability = document.getElementById("capability").value;
+  async function handleApprove(event) {
+    const button = event.target;
+    const capability = button.getAttribute("data-capability");
+    const email = button.getAttribute("data-email");
 
     try {
       const response = await fetch(
-        `/capabilities/${encodeURIComponent(
-          capability
-        )}/register?email=${encodeURIComponent(email)}`,
+        `/capabilities/${encodeURIComponent(capability)}/approve?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: getAuthHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
-        registerForm.reset();
-
-        // Refresh capabilities list to show updated consultants
+        showMessage(result.message, "success");
         fetchCapabilities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "Could not approve registration request.", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to approve request.", "error");
+      console.error("Error approving request:", error);
+    }
+  }
+
+  loginBtn.addEventListener("click", openLoginModal);
+  cancelLoginBtn.addEventListener("click", closeLoginModal);
+
+  logoutBtn.addEventListener("click", () => {
+    localStorage.removeItem("slalom_access_token");
+    authState.token = null;
+    authState.user = null;
+    updateAuthUI();
+    fetchCapabilities();
+    showMessage("Signed out successfully.", "info");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Sign in failed.", "error");
+        return;
       }
 
-      messageDiv.classList.remove("hidden");
+      authState.token = result.access_token;
+      authState.user = result.user;
+      localStorage.setItem("slalom_access_token", authState.token);
 
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      closeLoginModal();
+      updateAuthUI();
+      fetchCapabilities();
+      showMessage(`Welcome, ${result.user.display_name}!`, "success");
     } catch (error) {
-      messageDiv.textContent = "Failed to register. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign in.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  registerForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    if (!authState.user) {
+      showMessage("Sign in first to continue.", "error");
+      return;
+    }
+
+    const capability = capabilitySelect.value;
+    const email = authState.user.role === "consultant" ? authState.user.email : emailInput.value;
+
+    try {
+      const response = await fetch(
+        `/capabilities/${encodeURIComponent(capability)}/register?email=${encodeURIComponent(email)}`,
+        {
+          method: "POST",
+          headers: getAuthHeaders(),
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        showMessage(result.message, "success");
+        if (authState.user.role !== "consultant") {
+          registerForm.reset();
+        }
+        fetchCapabilities();
+      } else {
+        showMessage(result.detail || "Could not register consultant.", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to register consultant.", "error");
       console.error("Error registering:", error);
     }
   });
 
-  // Initialize app
-  fetchCapabilities();
+  (async () => {
+    await restoreSession();
+    updateAuthUI();
+    fetchCapabilities();
+  })();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,11 @@
   </head>
   <body>
     <header>
+      <div class="auth-toolbar">
+        <span id="auth-user" class="auth-user hidden"></span>
+        <button id="login-btn" class="auth-btn">Sign In</button>
+        <button id="logout-btn" class="auth-btn hidden">Sign Out</button>
+      </div>
       <div class="header-content">
         <img src="https://colby-timm.github.io/images/byte-teacher.png" alt="Byte mascot" class="mascot" />
         <div class="header-text">
@@ -28,6 +33,7 @@
 
       <section id="register-container">
         <h3>Register Your Expertise</h3>
+        <p id="register-help" class="helper-text">Sign in to register or request capability enrollment.</p>
         <form id="register-form">
           <div class="form-group">
             <label for="email">Consultant Email:</label>
@@ -52,6 +58,31 @@
         <p>&copy; 2025 Slalom • Building Better Tomorrow</p>
       </div>
     </footer>
+
+    <div id="login-modal" class="modal hidden" aria-hidden="true">
+      <div class="modal-dialog">
+        <h3>Practice Platform Sign In</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input id="username" name="username" autocomplete="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input id="password" name="password" type="password" autocomplete="current-password" required />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Sign In</button>
+            <button id="cancel-login-btn" type="button" class="secondary-btn">Cancel</button>
+          </div>
+        </form>
+        <p class="helper-text credentials-hint">
+          Demo accounts:<br />
+          <strong>tech.lead</strong> / LeadTech!2026<br />
+          <strong>alex.consultant</strong> / Consultant!2026
+        </p>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -31,6 +32,38 @@ header {
   justify-content: center;
   gap: 20px;
   flex-wrap: wrap;
+}
+
+.auth-toolbar {
+  position: absolute;
+  right: 16px;
+  top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.auth-user {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.auth-btn {
+  background: white;
+  color: #003d7a;
+  border: none;
+  border-radius: 999px;
+  padding: 8px 14px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.auth-btn:hover {
+  background: #e3f2fd;
 }
 
 .mascot {
@@ -123,6 +156,20 @@ section h3 {
   font-weight: 600;
 }
 
+.pending-section {
+  margin-top: 8px;
+  margin-bottom: 10px;
+  padding: 10px;
+  border: 1px solid #dbe7ff;
+  border-radius: 8px;
+  background: #f7faff;
+}
+
+.pending-section h5 {
+  margin-bottom: 8px;
+  color: #003d7a;
+}
+
 .consultants-section ul {
   list-style-type: none;
   padding-left: 5px;
@@ -157,6 +204,23 @@ section h3 {
   transition: all 0.2s;
   border-radius: 4px;
   font-weight: bold;
+}
+
+.approve-btn {
+  background: linear-gradient(135deg, #2e7d32, #1b5e20);
+  border: none;
+  color: white;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 8px;
+  transition: all 0.2s;
+  border-radius: 4px;
+  font-weight: bold;
+}
+
+.approve-btn:hover {
+  background: linear-gradient(135deg, #388e3c, #2e7d32);
+  transform: scale(1.05);
 }
 
 .delete-btn:hover {
@@ -206,6 +270,31 @@ button[type="submit"] {
   letter-spacing: 1px;
 }
 
+button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.65;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+.secondary-btn {
+  background: #eceff1 !important;
+  color: #37474f !important;
+}
+
+.helper-text {
+  margin-bottom: 12px;
+  color: #556;
+  font-size: 0.95rem;
+}
+
+.credentials-hint {
+  margin-top: 14px;
+  border-top: 1px solid #dce3f4;
+  padding-top: 10px;
+  color: #344;
+}
+
 button[type="submit"]:hover {
   background: linear-gradient(135deg, #0066cc, #1976d2);
   transform: translateY(-2px);
@@ -238,6 +327,37 @@ button[type="submit"]:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.modal-dialog {
+  width: 100%;
+  max-width: 420px;
+  background: white;
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.25);
+}
+
+.modal-dialog h3 {
+  margin-bottom: 14px;
+  color: #003d7a;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }
 
 footer {
@@ -287,6 +407,13 @@ footer {
 
 /* Responsive design improvements */
 @media (max-width: 768px) {
+  .auth-toolbar {
+    position: static;
+    justify-content: center;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+  }
+
   .header-content {
     flex-direction: column;
     gap: 10px;


### PR DESCRIPTION
## Summary

Implements issue #7 — Practice Lead Authorization System.

Adds token-based authentication, role-based access control, a consultant approval workflow, and an audit trail to the capabilities tracking app.

## Changes

### Backend (`src/app.py`)
- **`POST /auth/login`** — validates credentials from `practice_leads.json` using salted SHA-256 hashes, returns a signed token
- **`GET /auth/me`** — returns current session info (username, role, permissions)
- **Role-based access control** — `practice_lead` and `consultant` roles; unauthenticated read-only access preserved for the capabilities list
- **Approval workflow** — consultants submit registration requests; practice leads approve via `POST /capabilities/{capability}/approve`
- **`DELETE /capabilities/{capability}/unregister`** — restricted to practice leads
- **`GET /audit-logs`** — returns audit trail of all approval/unregister events (practice lead only)

### Credentials store (`src/practice_leads.json`) _(new)_
- Seeded with three demo users:
  - `tech.lead` — Practice Lead (Technology)
  - `strategy.lead` — Practice Lead (Strategy)
  - `alex.consultant` — Consultant

### Frontend
- **`src/static/index.html`** — auth toolbar (sign in/out + user badge), login modal, demo credentials hint
- **`src/static/app.js`** — token storage/restore, login/logout flow, role-aware registration (request vs direct), approve/unregister button rendering
- **`src/static/styles.css`** — styles for toolbar, modal, pending request section, and role-action buttons

### Docs (`src/README.md`)
- Updated feature list and API endpoint documentation
- Added demo credentials section

## Testing

Runtime smoke test confirmed the full flow:
- `CONSULTANT_LOGIN 200`
- `ME 200 consultant`
- `REQUEST 200` — consultant registration request submitted
- `APPROVE 200` — practice lead approval succeeds
- `AUDIT 200` — 2 audit entries recorded

Closes #7